### PR TITLE
supplement necessary instructions to run example-wasi

### DIFF
--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -3,6 +3,7 @@ Example of instantiating a WebAssembly which uses WASI imports.
 
 You can compile and run this example on Linux with:
 
+   cmake example/
    cargo build --release -p wasmtime-c-api
    cc examples/wasi/main.c \
        -I crates/c-api/include \

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -1,7 +1,11 @@
 //! Example of instantiating of instantiating a wasm module which uses WASI
 //! imports.
 
-// You can execute this example with `cargo run --example wasi`
+/*
+You can execute this example with:
+    cmake example/
+    cargo run --example wasi
+*/
 
 use anyhow::Result;
 use wasmtime::*;


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

The instructions in ``examples/wasi/main.c`` and ``examples/wasi/main.rs`` lack a necessary step to generate ``wasi.wasm`` into    ``target/wasm32-wasi/debug/``.


